### PR TITLE
Add `main` entry to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "webmaker-analytics",
   "version": "0.1.4",
+  "main": "analytics.js",
   "repository": {
     "type": "git",
     "url": "git://github.com/mozilla/webmaker-analytics.git"


### PR DESCRIPTION
The `main` entry is required to make the package requireable.
